### PR TITLE
Event payload changes to match elsewhere

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,4 @@
 # Maintainers
 
 - [sdashner](https://github.com/sdashner) seandashner [at] gmail.com
+- [DominicDC](https://github.com/DominicDC) coutinho.dominic [at] outlook.com

--- a/README.md
+++ b/README.md
@@ -67,22 +67,22 @@ install them.
 
 | Parameter Name | Required | Description            | Type   | Default   |
 | -------------- | -------- | ---------------------- | ------ | --------- |
-| customerUid    | yes      | customer identifier    | number |           |
-| projectId      | yes      | project identifier     | number |           |
-| projectVersion | no       | project version number | number | undefined |
+| customerUid    | yes      | customer identifier    | string |           |
+| projectId      | yes      | project identifier     | string |           |
+| projectVersion | no       | project version        | string |           |
 | brand          | yes      | brand description      | string |           |
 | style          | yes      | style description      | string |           |
 | color          | yes      | color                  | string |           |
 | url            | yes      | thumbnail image url    | string |           |
-| bom            | yes      | bill of materials      | object |           |
+| bom            | yes      | bill of materials      | string |           |
 
 ### `designerHandOff`
 
 | Parameter Name | Required | Description            | Type   | Default   |
 | -------------- | -------- | ---------------------- | ------ | --------- |
-| customerUid    | yes      | customer identifier    | number |           |
-| projectId      | yes      | project identifier     | number |           |
-| projectVersion | no       | project version number | number | undefined |
+| customerUid    | yes      | customer identifier    | string |           |
+| projectId      | yes      | project identifier     | string |           |
+| projectVersion | no       | project version        | string |           |
 | brand          | yes      | brand description      | string |           |
 | style          | yes      | style description      | string |           |
 | color          | yes      | color                  | string |           |
@@ -142,6 +142,7 @@ information.
 
 - [@sean_dashner](https://twitter.com/sean_dashner)
 - seandashner@gmail.com
+- coutinho.dominic@outlook.com
 
 Project Link:
 [https://github.com/wayfair-incubator/postmessage-communicator](https://github.com/wayfair-incubator/postmessage-communicator)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postmessage-communicator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "[![Release](https://img.shields.io/github/v/release/wayfair-incubator/oss-template?display_name=tag)](CHANGELOG.md) [![Lint](https://github.com/wayfair-incubator/oss-template/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/wayfair-incubator/oss-template/actions/workflows/lint.yml) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md) [![Maintainer](https://img.shields.io/badge/Maintainer-Wayfair-7F187F)](https://wayfair.github.io)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/classes/VendorCommunicator.ts
+++ b/src/classes/VendorCommunicator.ts
@@ -17,7 +17,7 @@ interface Metadata {
   brand: string;
   style: string;
   color: string;
-  thumbnailUri: string;
+  thumbnailUrl: string;
   area?: number;
 }
 
@@ -26,7 +26,7 @@ interface EventPayload {
   token: string;
   customerId: string;
   projectId: string;
-  versionId: number;
+  versionId: string;
   metadata: Metadata;
   bom?: any;
 }


### PR DESCRIPTION
## Description

This PR changes the event payload to match other repositories:

- Renamed `thumbnailUri` to `thumbnailUrl`
- Changed datatype of ProjectVersion from `number` to `string`
- Bumped the version from `1.0.0` to `1.0.1`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/postmessage-communicator/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
